### PR TITLE
Fixed extra booster disappearing after hpurchasing max level

### DIFF
--- a/backend/boosts/dependencies.py
+++ b/backend/boosts/dependencies.py
@@ -137,7 +137,9 @@ def upgrade_extra_boost(extra_boost_id: str, telegram_user_id: str):
         }
         booster_name = booster_names[ebooster_name]
 
-
+        if user["extra_boost"][booster_name] == 5:
+            raise HTTPException(status_code=400, detail="You have reached the maximum level for this booster.")
+        
         update = user_collection.update_one(
             {"telegram_user_id": telegram_user_id},
             {


### PR DESCRIPTION
- **route to delete users now available**
- **route to delete users now available**
- **Clan structure in place, added ownership status to auto_bot_tap**
- **create clan route now available**
- **fixed existing users signing up again(creating duplicate)**
- **created more routes for clan interactivity**
- **fixed extra booster disappearing when highest level(5) purchase is exceeded**
