### PR TITLE
Clan update: rank and earnings + streak status update

### DIFF
--- a/backend/clan/router.py
+++ b/backend/clan/router.py
@@ -8,6 +8,7 @@ from clan.dependencies import (
     create_clan as create_clan_func,
     join_clan as join_clan_func,
     all_clans as all_clans_func,
+    run_clan_earnings,
     top_clans as top_clans_func,
     my_clan as my_clan_func,
     exit_clan as exit_clan_func
@@ -20,7 +21,7 @@ user_clan_router = APIRouter(
     prefix="/user/clan",
     tags=["Clan"],
     # responses={404: {"description": "Not found"}},
-    dependencies=[Depends(get_current_user)]
+    dependencies=[Depends(get_current_user), Depends(run_clan_earnings)]
 )
 
 

--- a/backend/earn/router.py
+++ b/backend/earn/router.py
@@ -113,9 +113,14 @@ async def perform_streak(telegram_user_id: Annotated[str, Depends(get_current_us
 
         return reset_streak
     
+    remaining_wait_time = timedelta(hours=24) - time_difference
+    hrs = remaining_wait_time.total_seconds() // 3600
+    mins = (remaining_wait_time.total_seconds() // 60) % 60
+    secs = remaining_wait_time.total_seconds() % 60
+
     return {
         "message": "Streak not updated",
-        "Countdown": f"check again by this time: {old_streak.last_action_date.strftime('%I:%M %p')} tomorrow"
+        "Count": f"check again in the next {int(hrs)} hrs:{int(mins)} mins:{int(secs)} secs"
     }
 
 

--- a/backend/superuser/clan/models.py
+++ b/backend/superuser/clan/models.py
@@ -24,6 +24,7 @@ class Clan(BaseModel):
     status: str = ClanStatus.PENDING
     image_id: str
     members: int
+    last_earn_date: datetime | None = None
 
 
 class ClanModelResponse(Clan, ID):


### PR DESCRIPTION
- **fixed clan members not accessible in clan creation**
- **removed some unnecessary lines of code**
- **clan exit route now available**
- **added power limit and last active time to user profile**
- **new route: profile photo url and added auto bot status to profile**
- **added status field to my_clan route**
- **creating clan routes for admin**
- **added user unique id to profile response**
- **added invitee's invite count to /invitees route**
- **modified extra boosters level logic**
- **updated clans with earnings and rankings and updated streak to return a countdown of remaining time to next streak**
