### PR TITLE
updated clan name in leaderboard response

### DIFF
--- a/backend/superuser/leaderboard/dependencies.py
+++ b/backend/superuser/leaderboard/dependencies.py
@@ -16,7 +16,7 @@ def process_result_from_aggregation(result):
             level=data["level"],
             level_name=data["level_name"],
             coins_earned=data["total_coins"],
-            clan="clan",
+            clan=data["clan"],
             longest_streak=data["longest_streak"]
         )
 
@@ -47,7 +47,7 @@ def all_time_leaderboard():
                 'level': "$user_info.level",
                 'level_name': "$user_info.level_name",
                 'total_coins': 1,
-                # 'clan': "$user_info.clan",
+                'clan': "$user_info.clan.name",
                 'longest_streak': "$user_info.streak.longest_streak",
                 'image_url': 1,
                 'telegram_user_id': 1,
@@ -95,7 +95,7 @@ def daily_leaderboard():
                 'level': "$user_info.level",
                 'level_name': "$user_info.level_name",
                 'total_coins': 1,
-                # 'clan': "$user_info.clan",
+                'clan': "$user_info.clan.name",
                 'longest_streak': "$user_info.streak.longest_streak",
                 'image_url': "$user_info.image_url",
                 'telegram_user_id': 1,
@@ -184,7 +184,7 @@ def weekly_leaderboard():
                 'level': "$user_info.level",
                 'level_name': "$user_info.level_name",
                 'total_coins': 1,
-                # 'clan': "$user_info.clan",
+                'clan': "$user_info.clan.name",
                 'longest_streak': "$user_info.streak.longest_streak",
                 'image_url': "$user_info.image_url",
                 '_id': 0
@@ -266,7 +266,8 @@ def monthly_leaderboard():
                 'username': '$user_info.username', 
                 'level': '$user_info.level', 
                 'level_name': '$user_info.level_name', 
-                'total_coins': 1, 
+                'total_coins': 1,
+                'clan': "$user_info.clan.name",
                 'longest_streak': '$user_info.streak.longest_streak', 
                 'image_url': '$user_info.image_url', 
                 '_id': 0

--- a/backend/superuser/leaderboard/schemas.py
+++ b/backend/superuser/leaderboard/schemas.py
@@ -38,7 +38,7 @@ class LeaderBoard(BaseModel):
     level: int
     level_name: str
     coins_earned: int
-    clan: str
+    clan: str | None
     longest_streak: int
 
 class LeaderBoardUserProfile(BaseModel):


### PR DESCRIPTION
- **updated clan member count and creator field upon leadership transfer**
- **added new leader username to response**
- **delete route updated**
- **refactored routes to use pagination**
- **added percentage increase readings to dashboard**
- **fixed clan creator username showing as ID**
- **new users created_at now use standard UTC timing**
- **clan earnings now gets updated in coin stats**
- **added coin stats update func to clan earnings to update coin stats**
- **added coin stats update func to update coin stats**
- **done with clan for admin**
- **added func descriptions to functions**
- **created route to get clan profile image**
- **created app search route**
- **rewards claim rate now effective**
- **created raise suspension route**
- **ban status now visible in user management**
- **implemented strict to-the-microseconds timing for resumption of suspended users**
- **added clan data to userprofile from admin leader board route**
- **updated clan name in leaderboard response**
