### PR TITLE
challenges and rewards can noow use username or id to represent participants and clan is now being verified upon any entity creation that requires clan be verified

### DIFF
--- a/backend/reward/dependencies.py
+++ b/backend/reward/dependencies.py
@@ -10,17 +10,22 @@ def my_on_going_rewards(telegram_user_id: str):
     my_data: dict = user_collection.find_one({"telegram_user_id": telegram_user_id})
 
     if my_data:
-        my_level: str = my_data["level_name"].lower()
-        my_clan = my_data["clan"]["name"]
+        my_username: str = my_data["username"]
+        my_level: str = my_data["level"]
+        my_level_name: str = my_data["level_name"].lower()
+        my_clan_id = my_data["clan"]["id"]
+        my_clan_name = my_data["clan"]["name"]
         my_claimed_rewards = my_data["claimed_rewards"]
+
+        conditions = [
+            "all_users", my_username, telegram_user_id, 
+            my_level, my_level_name, 
+            my_clan_name, my_clan_id
+        ]
 
         for reward in get_rewards():
             if reward.status == "on_going" and reward.id not in my_claimed_rewards:
-                if my_level in reward.beneficiary or \
-                    my_clan in reward.beneficiary or \
-                    "all_users" in reward.beneficiary or \
-                    telegram_user_id in reward.beneficiary:
-
+                if any(condition in reward.beneficiary for condition in conditions):
                     # update to increment impression count
                     update_reward = {
                         "$inc": {

--- a/backend/superuser/challenge/router.py
+++ b/backend/superuser/challenge/router.py
@@ -47,9 +47,9 @@ async def create_challenge(
     Creates a new challenge in the system.
 
     Args:
-        clan (list[str] | None, optional): List of clan IDs participating in the challenge.
-        level (list[str] | None, optional): List of level IDs participating in the challenge.
-        specific_users (list[str] | None, optional): List of specific user IDs participating in the challenge.
+        clan (list[str] | None, optional): List of clan IDs/names participating in the challenge.
+        level (list[str] | None, optional): List of level name(s) participating in the challenge.
+        specific_users (list[str] | None, optional): List of specific user IDs/usernames participating in the challenge.
         challenge (CreateChallenge, optional): The challenge data being created.
 
     Raises:

--- a/backend/superuser/reward/router.py
+++ b/backend/superuser/reward/router.py
@@ -45,6 +45,21 @@ async def create_reward(
         specific_users: list[str] | None = None,
         new_reward: CreateReward = Depends(CreateReward),
     ) -> RewardsModelResponse:
+    """
+    Creates a new reward in the system.
+
+    Args:
+        clan (list[str] | None, optional): List of clan IDs/names participating in the reward.
+        level (list[str] | None, optional): List of level name(s) participating in the reward.
+        specific_users (list[str] | None, optional): List of specific user IDs/usernames participating in the reward.
+        new_reward (CreateReward, optional): The reward data being created.
+
+    Raises:
+        HTTPException: If the reward image is not provided or if the image format is invalid.
+
+    Returns:
+        RewardsModelResponse: The response model containing the details of the created reward.
+    """
     if not new_reward.reward_image:
         raise HTTPException(status_code=400, detail="Please upload a reward image.")
 

--- a/backend/superuser/task/router.py
+++ b/backend/superuser/task/router.py
@@ -27,7 +27,27 @@ task_router = APIRouter(
 
 # --------------------------------- CREATE TASK ---------------------------------
 @task_router.post("/create_task", status_code=201, response_model=TaskSchemaResponse)
-async def create_task(task = Depends(CreateTask)):
+async def create_task(task: CreateTask = Depends(CreateTask)):
+    """
+    Endpoint to create a new task in the system.
+
+    This endpoint checks if a task with the given name already exists.
+    If it does, it raises an HTTP exception. Otherwise, it validates
+    the task image if provided and creates a new task with the specified
+    details.
+
+    Args:
+        task (CreateTask): Task data, including name, type, description,
+                           status, participants, reward, image, and deadline.
+                           Participants are either all users, a level or list of levels
+
+    Returns:
+        TaskSchemaResponse: The created task data with an assigned ID.
+
+    Raises:
+        HTTPException: If a task with the specified name already exists.
+    """
+
     # check if task already exists
     task_already_exists = task_exists_in_db(task.task_name)
 


### PR DESCRIPTION
- **updated clan member count and creator field upon leadership transfer**
- **added new leader username to response**
- **delete route updated**
- **refactored routes to use pagination**
- **added percentage increase readings to dashboard**
- **fixed clan creator username showing as ID**
- **new users created_at now use standard UTC timing**
- **clan earnings now gets updated in coin stats**
- **added coin stats update func to clan earnings to update coin stats**
- **added coin stats update func to update coin stats**
- **done with clan for admin**
- **added func descriptions to functions**
- **created route to get clan profile image**
- **created app search route**
- **rewards claim rate now effective**
- **created raise suspension route**
- **ban status now visible in user management**
- **implemented strict to-the-microseconds timing for resumption of suspended users**
- **added clan data to userprofile from admin leader board route**
- **updated clan name in leaderboard response**
- **added dependency to update expired reward's status**
- **added dependency to update expired reward's status**
- **added dependency to update expired reward's status**
- **added float | int to claim_rate hint type in it's model response**
- **fixed rewards for levels not visible**
- **sorted levels in ascending order**
- **updated level_update logic to fix unbound local variable**
- **updated level_update logic to fix unbound local variable**
- **updated level_update logic to fix unbound local variable**
- **fixed level update logic**
- **fixed level update logic**
- **added clan verification when creating rewards for clans**
- **added clan verification when creating challenges for clans**
- **added clan verification when creating rewards for clans**
- **added docstring to create task endpoint**
