### PR TITLE
reward claim rate is now in 1 decimal place and remaining time countdown in challenge is now effective

### DIFF
--- a/backend/superuser/challenge/dependencies.py
+++ b/backend/superuser/challenge/dependencies.py
@@ -257,6 +257,16 @@ def get_challenges(status: str):
         challenge_launch_date: datetime = challenge["launch_date"]
 
         remaining_time = calculate_remaining_time(challenge_duration, challenge_launch_date)
+        
+        if remaining_time == "00:00:00:00":
+            # update remaining time in db
+            update_operation = {
+                "$set": {
+                    "remaining_time": remaining_time
+                }
+            }
+            challenges_collection.update_one({"_id": ObjectId(challenge['_id'])}, update_operation)
+
         # ongoing challenges
         if status == "ongoing" and remaining_time != "00:00:00:00":
             challenge["remaining_time"] = remaining_time
@@ -284,8 +294,14 @@ def get_challenge_by_id(challenge_id: str):
 
     if not challenge:
         raise HTTPException(status_code=404, detail="Challenge not found/Invalid challenge id.")
+    
+    challenge_duration: str = challenge["duration"]
+    challenge_launch_date: datetime = challenge["launch_date"]
 
+    remaining_time = calculate_remaining_time(challenge_duration, challenge_launch_date)
+    challenge["remaining_time"] = remaining_time
     challenge["image_id"] = str(challenge["image_id"])
+
 
     return ChallengeModelResponse(
         id=str(challenge["_id"]),

--- a/backend/superuser/reward/dependencies.py
+++ b/backend/superuser/reward/dependencies.py
@@ -83,7 +83,6 @@ def set_datetime_to_utc(date_time: datetime):
     return date_time
 
 
-
 # ------------------------------- CREATE REWARD ------------------------------ #
 def create_reward(reward: CreateReward, reward_image: bytes, image_name: str):
     image_id = fs.put(reward_image, filename="reward_" + image_name)
@@ -138,6 +137,7 @@ def get_reward_image(image_id: str):
     image_buffer = BytesIO(reward_image.read())
     image_buffer.seek(0)
     return StreamingResponse(image_buffer, media_type="image/jpeg")
+
 
 def update_reward(reward: UpdateReward, reward_image: bytes, img_name: str, reward_id: str):
 
@@ -234,8 +234,8 @@ def get_rewards():
     for reward in rewards:
         impression = reward["impression_count"]
         claim_count = reward["claim_count"]
-        claim_rate = ((claim_count / impression) * 100) if impression > 0 else 0.00
-        rewards_collection.update_one({"_id": reward["_id"]}, {"$set": {"claim_rate": round(claim_rate, 2)}})
+        claim_rate = ((claim_count / impression) * 100) if impression > 0 else 0.0
+        rewards_collection.update_one({"_id": reward["_id"]}, {"$set": {"claim_rate": round(claim_rate, 1)}})
         yield RewardsModelResponse(
             id=str(reward["_id"]),
             reward_title=reward["reward_title"],
@@ -293,7 +293,6 @@ def get_rewards_by_date(date: datetime):
                 claim_rate=f"{reward['claim_rate']}%",
                 reward_image_id=reward["reward_image_id"]
             )
-
 
 
 def update_status_of_expired_rewards():


### PR DESCRIPTION
- **updated clan member count and creator field upon leadership transfer**
- **added new leader username to response**
- **delete route updated**
- **refactored routes to use pagination**
- **added percentage increase readings to dashboard**
- **fixed clan creator username showing as ID**
- **new users created_at now use standard UTC timing**
- **clan earnings now gets updated in coin stats**
- **added coin stats update func to clan earnings to update coin stats**
- **added coin stats update func to update coin stats**
- **done with clan for admin**
- **added func descriptions to functions**
- **created route to get clan profile image**
- **created app search route**
- **rewards claim rate now effective**
- **created raise suspension route**
- **ban status now visible in user management**
- **implemented strict to-the-microseconds timing for resumption of suspended users**
- **added clan data to userprofile from admin leader board route**
- **updated clan name in leaderboard response**
- **added dependency to update expired reward's status**
- **added dependency to update expired reward's status**
- **added dependency to update expired reward's status**
- **added float | int to claim_rate hint type in it's model response**
- **fixed rewards for levels not visible**
- **sorted levels in ascending order**
- **updated level_update logic to fix unbound local variable**
- **updated level_update logic to fix unbound local variable**
- **updated level_update logic to fix unbound local variable**
- **fixed level update logic**
- **fixed level update logic**
- **added clan verification when creating rewards for clans**
- **added clan verification when creating challenges for clans**
- **added clan verification when creating rewards for clans**
- **added docstring to create task endpoint**
- **added try...except block in clan verifications when creating rewards for clans**
- **removed clan verifications by ID**
- **task remaining time countdown now reflecting in rewards when fetched**
- **formatted claim rate value to 1 decimal place**
