### PR TITLE
tasks is now editable not minding if it's even about reaching it's deadline

### DIFF
--- a/backend/superuser/task/dependencies.py
+++ b/backend/superuser/task/dependencies.py
@@ -74,6 +74,33 @@ def validate_task_deadline(deadline: datetime):
     return deadline
 
 
+def validate_task_update_deadline(deadline: datetime):
+    """
+    Converts the given deadline datetime to UTC timezone and ensures it's a future date from the current date.
+
+    Args:
+        deadline (datetime): The task deadline to validate.
+
+    Returns:
+        datetime: The validated deadline datetime in UTC timezone.
+
+    Raises:
+        HTTPException: If the deadline is not a future date from the current date.
+    """
+    # convert deadline timezone to utc and ensure it's greater than current time
+    today = datetime.now(timezone.utc)
+    if deadline.tzinfo:
+        deadline = deadline.astimezone(timezone.utc)
+    else:
+        deadline = deadline.replace(tzinfo=timezone.utc)
+
+    deadline = deadline.replace(hour=today.hour, minute=today.minute, second=today.second, microsecond=today.microsecond, tzinfo=timezone.utc)
+    if deadline < today:
+        raise HTTPException(status_code=400, detail="task deadline date has to be a future date/time.")
+
+    return deadline
+
+
 def extract_url_from_description(description: str):
     """
     Extracts the first URL from a given description string.

--- a/backend/superuser/task/models.py
+++ b/backend/superuser/task/models.py
@@ -63,7 +63,7 @@ class TaskModelResponse(BaseModel):
     task_status: TaskStatus
     task_participants: TaskParticipants | list[TaskParticipants]
     task_reward: int
-    task_image_id: bytes | None
+    task_image_id: str | None = None
     created_at: datetime = datetime.now(timezone.utc)
     last_updated: datetime | None = None
     task_deadline: datetime
@@ -76,7 +76,7 @@ class UpdateTask(BaseModel):
     task_status: TaskStatus
     task_participants: TaskParticipants | list[TaskParticipants]
     task_reward: int
-    task_image_id: str | None
+    task_image_id: str | None = None
     # created_at: datetime = datetime.now()
     last_updated: datetime = None
     task_deadline: datetime

--- a/backend/superuser/task/router.py
+++ b/backend/superuser/task/router.py
@@ -17,7 +17,8 @@ from superuser.task.dependencies import (
         get_tasks_by_status as get_tasks_by_status_func,
         delete_task as delete_task_func,
         # export_tasks as export_tasks_func,
-        validate_task_deadline
+        validate_task_deadline,
+        validate_task_update_deadline
     )
 
 
@@ -119,7 +120,7 @@ async def update_task(task_id: str, task: UpdateTask = Depends(UpdateTask)):
     if not task_exists:
         raise HTTPException(status_code=404, detail="Task not found.")
 
-    deadline = validate_task_deadline(task.task_deadline)
+    deadline = validate_task_update_deadline(task.task_deadline)
     task_url = extract_url_from_description(task.task_description)
 
     # validate image if modified

--- a/backend/superuser/task/schemas.py
+++ b/backend/superuser/task/schemas.py
@@ -13,7 +13,7 @@ class CreateTask(BaseModel):
     task_participants: Union[TaskParticipants, List[TaskParticipants]]
     task_reward: Annotated[int, Form(...)]
     task_deadline: Annotated[datetime, Form(...)]
-    task_image: Annotated[UploadFile, Form(description="Upload task image", media_type="multipart/form-data")]
+    task_image: Annotated[UploadFile | str | None, Form(description="Upload task image", media_type="multipart/form-data")] = None
 
 
 class UpdateTask(BaseModel):
@@ -35,7 +35,7 @@ class TaskSchema(BaseModel):
     task_status: TaskStatus
     task_participants: TaskParticipants | list[TaskParticipants]
     task_reward: int
-    task_image_id: str | None
+    task_image_id: str | None = None
     task_deadline: datetime
 
 class TaskSchemaResponse(BaseModel):
@@ -47,5 +47,5 @@ class TaskSchemaResponse(BaseModel):
     task_status: str
     task_participants: str | list[str]
     task_reward: int
-    task_image_id: str | None
+    task_image_id: str | None = None
     task_deadline: datetime

--- a/backend/tasks/dependencies.py
+++ b/backend/tasks/dependencies.py
@@ -27,6 +27,7 @@ def my_tasks_by_type(telegram_user_id: str, task_type: str, skip: int = 0, limit
                 task_image_id=task.get("task_image_id", None),
                 task_description=task.get("task_description", None),
                 task_url=task.get("task_url", None),
+                task_participants=task.get("task_participants", None),
                 task_deadline=task.get("task_deadline", None)
             )
         )

--- a/backend/tasks/schemas.py
+++ b/backend/tasks/schemas.py
@@ -26,5 +26,6 @@ class MyTasks(BaseModel):
     task_reward: int
     task_image_id: str
     task_description: str
+    task_participants: list[str]
     task_url: str | None = None
     task_deadline: datetime


### PR DESCRIPTION
- **updated clan member count and creator field upon leadership transfer**
- **added new leader username to response**
- **delete route updated**
- **refactored routes to use pagination**
- **added percentage increase readings to dashboard**
- **fixed clan creator username showing as ID**
- **new users created_at now use standard UTC timing**
- **clan earnings now gets updated in coin stats**
- **added coin stats update func to clan earnings to update coin stats**
- **added coin stats update func to update coin stats**
- **done with clan for admin**
- **added func descriptions to functions**
- **created route to get clan profile image**
- **created app search route**
- **rewards claim rate now effective**
- **created raise suspension route**
- **ban status now visible in user management**
- **implemented strict to-the-microseconds timing for resumption of suspended users**
- **added clan data to userprofile from admin leader board route**
- **updated clan name in leaderboard response**
- **added dependency to update expired reward's status**
- **added dependency to update expired reward's status**
- **added dependency to update expired reward's status**
- **added float | int to claim_rate hint type in it's model response**
- **fixed rewards for levels not visible**
- **sorted levels in ascending order**
- **updated level_update logic to fix unbound local variable**
- **updated level_update logic to fix unbound local variable**
- **updated level_update logic to fix unbound local variable**
- **fixed level update logic**
- **fixed level update logic**
- **added clan verification when creating rewards for clans**
- **added clan verification when creating challenges for clans**
- **added clan verification when creating rewards for clans**
- **added docstring to create task endpoint**
- **added try...except block in clan verifications when creating rewards for clans**
- **removed clan verifications by ID**
- **task remaining time countdown now reflecting in rewards when fetched**
- **formatted claim rate value to 1 decimal place**
- **refactored tasks**
- **origins updated**
- **tasks is now editable not minding if it's even about reaching it's deadline**
